### PR TITLE
Replaced "redeal" with "new game"

### DIFF
--- a/server.py
+++ b/server.py
@@ -295,6 +295,10 @@ def actionFinishRound(player):
 				game_data['score'][oppTeam] += 10 * oppTricks
 		actionDeal()
 
+def actionNewGame():
+	actionDeal()
+	game_data['score'] = [0, 0]
+
 def actionChangeName(player):
 	name = bottle.request.forms.get('name')
 	if isValidName(name):
@@ -339,14 +343,17 @@ def page_action():
 	if 0 <= player < 4:
 		# Play or discard a card
 		if action == 'play': actionPlay(card, player)
-		# Completely redeal cards
-		if action == 'redeal': actionDeal()
+		# Start a fresh new game
+		if action == 'newgame': actionNewGame()
 		# Clear the table
 		if action == 'clear': actionClear()
+		# Pick up a card
 		if action == 'pickup': actionPickup(card, player)
 		# Add a bet
 		if action == 'setBet': actionSetBet(player)
+		# Finish a round
 		if action == 'finishRound': actionFinishRound(player)
+		# Change a name
 		if action == 'changeName': actionChangeName(player)
 		# Increment version counter
 		game_data['version_id'] += 1

--- a/static/game.html
+++ b/static/game.html
@@ -25,7 +25,7 @@
 						<h2>Controls</h2>
 						<h3>Actions</h3>
 						<button onclick="uniAction('clear');">Clear Table</button>
-						<button onclick="actionRedeal();">Redeal</button>
+						<button onclick="actionNewGame();">New Game</button>
 						<h3>Change Player</h3>
 						<button onclick="changePlayer(0);">Be player 1</button>
 						<button onclick="changePlayer(1);">Be player 2</button>

--- a/static/game.js
+++ b/static/game.js
@@ -256,10 +256,10 @@ function cardPickup(card) {
 	});
 }
 
-function actionRedeal() {
-	var query = window.confirm("Redeal the cards?");
+function actionNewGame() {
+	var query = window.confirm("Start a new game?\nThis will reset all scores.");
 	if (query) {
-		uniAction('redeal');
+		uniAction('newgame');
 	}
 }
 

--- a/static/game.js
+++ b/static/game.js
@@ -190,6 +190,8 @@ function updateGameView(data, status) {
 		$("#floorCards").html(makeTableTable(data.floor, false, data.names));
 		if (data.kitty.length == 0) { // bet exists and is confirmed
 			$("#betInfo").text(makeBetText(data.betPlayer, data.betAmount, data.betSuit, data.names));
+			myBetAmount = -1; // reset things
+			myBetSuit = '';
 		} else { // still in betting phase
 			var betInfoHtml = "You are considering betting "+makeBetTextNoPlayer(myBetAmount, myBetSuit);
 			if (isProperBet(myBetAmount, myBetSuit))


### PR DESCRIPTION
New game resets all the scores.
<i>redeal</i> is redundant as this is automated by <i>new game</i> and <i>finish round</i>.

Also reset bet considerations/properties for each new round.
<b>This is currently broken if all four players pass.</b>

Maybe merge this branch into master for when dx returns.